### PR TITLE
Allowing resample accept more image formats

### DIFF
--- a/src/Controller/Component/ImageComponent.php
+++ b/src/Controller/Component/ImageComponent.php
@@ -151,7 +151,20 @@ class ImageComponent extends Component
         $backColor = ImageColorAllocate($dst, 0, 0, 0);
         ImageFilledRectangle($dst, 0, 0, $dst_w, $dst_h, $backColor);
 
-        $src = imagecreatefromjpeg($srcPath);
+        $exploded = explode('.', $image);
+        $ext = $exploded[count($exploded) - 1];
+
+        if (preg_match('/jpg|jpeg/i', $ext)) {
+            $src = imagecreatefromjpeg($srcPath);
+        }else if (preg_match('/png/i', $ext)) {
+            $src = imagecreatefrompng($srcPath);
+        }else if (preg_match('/gif/i', $ext)) {
+            $src = imagecreatefromgif($srcPath);
+        }else if (preg_match('/bmp/i', $ext)) {
+            $src = imagecreatefrombmp($srcPath);
+        }else {
+            $src = imagecreatefromjpeg($srcPath);
+        }
 
         ImageCopyResampled($dst, $src, $dst_x, $dst_y, 0, 0, $new_w, $new_h, $src_w, $src_h);
         imagejpeg($dst, $dstPath, 100);


### PR DESCRIPTION
This will check the image extension and apply the corresponding function according to its extension. 
In case the extension is not found then it will try to apply the `imagecreatefromjpeg()` function to it causing the same results than before.